### PR TITLE
Remove emojis from description

### DIFF
--- a/python_scripts/dynamic_data.py
+++ b/python_scripts/dynamic_data.py
@@ -131,6 +131,12 @@ for p in projects_gh:
 
     if (p in projects_api):
         p_api = projects_api[p]
+
+        # replace \u2019 with ' in description
+        p_api['description'] = p_api['description'].replace('\u2019', "'")
+        # remove emojis from description
+        p_api['description'] = p_api['description'].encode('ascii', 'ignore').decode('ascii')
+        
         proj['description'] = p_api['description']
         proj['category'] = p_api['category']
         proj['project_url'] = p_api['project_url']


### PR DESCRIPTION
bundle exec jekyll serve


`(/mnt/c/Users/IshanFernando/Desktop/clones/projects.ce.pdn.ac.lk/_data/projects.json): found invalid Unicode character escape code while parsing a quoted scalar at line 30776 column 24 (Psych::SyntaxError)`


The line with error (line 30776 projects.json)
` "description": "CricVision: Unlocking cricket insights through machine learning! Analyze Sri Lanka\u2019s international matches, predict player impact, and gain valuable insights for teams and fans. \ud83c\udfcf\ud83d\udd0d",`

github repo of that project - https://github.com/cepdnaclk/e19-co544-cricket-analytics-and-prediction
The description of the repo contains some emojis. 
![image](https://github.com/cepdnaclk/projects.ce.pdn.ac.lk/assets/73381996/2a0d2eba-b6c3-48b5-9b1e-0f67f863fa7f)

I removed the emojis from the jsons manually and it built successfully. 

Modified the python script to remove emojis from the description.
This should fix the build errors.